### PR TITLE
Revert "Added DataUsageProvider to the build"

### DIFF
--- a/target/product/core.mk
+++ b/target/product/core.mk
@@ -28,7 +28,6 @@ PRODUCT_PACKAGES += \
     CaptivePortalLogin \
     CertInstaller \
     Contacts \
-    DataUsageProvider \
     DeskClock \
     DocumentsUI \
     DownloadProviderUi \


### PR DESCRIPTION
- CM specific packages should go into vendor/cm

This reverts commit 0c03d1e623e77bab4825da899e52b4ffc849a3af.

Change-Id: I5810111672a4566def56df80e9cdc9bd1e158c70
